### PR TITLE
Check if the Types is flagged as 'Front'

### DIFF
--- a/Jellyfin.Plugin.CoverArtArchive/CoverArtArchiveImageProvider.cs
+++ b/Jellyfin.Plugin.CoverArtArchive/CoverArtArchiveImageProvider.cs
@@ -112,7 +112,7 @@ namespace Jellyfin.Plugin.CoverArtArchive
                     {
                         var release = await _coverArtClient.FetchGroupReleaseAsync(Guid.Parse(musicBrainzGroupId)).ConfigureAwait(false);
 
-                        var frontImage = release.Images.FirstOrDefault(image => image.Types == CoverArtType.Front);
+                        var frontImage = release.Images.FirstOrDefault(image => image.Types.HasFlag(CoverArtType.Front));
 
                         if (frontImage is not null)
                         {


### PR DESCRIPTION
This PR checks if the enum/flags `Types` of the CovertArt is flagged as `Front`. In cases where the image has multiples types, such as [this one](https://ia802906.us.archive.org/19/items/mbid-e1cb7ea3-e5f4-4ce9-be33-1c52bdc0f552/index.json), the plugin was discarding incorrectly the image. This PR should fix this behavior.