### PR TITLE
Unstable: Update to latest Jellyfin preview packages

### DIFF
--- a/Jellyfin.Plugin.CoverArtArchive/Jellyfin.Plugin.CoverArtArchive.csproj
+++ b/Jellyfin.Plugin.CoverArtArchive/Jellyfin.Plugin.CoverArtArchive.csproj
@@ -7,7 +7,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <NoWarn>$(NoWarn);CA1873</NoWarn>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/Jellyfin.Plugin.CoverArtArchive/Jellyfin.Plugin.CoverArtArchive.csproj
+++ b/Jellyfin.Plugin.CoverArtArchive/Jellyfin.Plugin.CoverArtArchive.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Jellyfin.Model" Version="12.*-*" />
     <PackageReference Include="MetaBrainz.Common.Json" Version="7.2.0" />
     <PackageReference Include="MetaBrainz.MusicBrainz.CoverArt" Version="7.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.CoverArtArchive/Jellyfin.Plugin.CoverArtArchive.csproj
+++ b/Jellyfin.Plugin.CoverArtArchive/Jellyfin.Plugin.CoverArtArchive.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Jellyfin.Model" Version="10.*-*" />
     <PackageReference Include="MetaBrainz.Common.Json" Version="7.1.0" />
     <PackageReference Include="MetaBrainz.MusicBrainz.CoverArt" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.CoverArtArchive/Jellyfin.Plugin.CoverArtArchive.csproj
+++ b/Jellyfin.Plugin.CoverArtArchive/Jellyfin.Plugin.CoverArtArchive.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
-    <PackageReference Include="Jellyfin.Model" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.*-*" />
+    <PackageReference Include="Jellyfin.Model" Version="12.*-*" />
     <PackageReference Include="MetaBrainz.Common.Json" Version="7.1.0" />
     <PackageReference Include="MetaBrainz.MusicBrainz.CoverArt" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />

--- a/Jellyfin.Plugin.CoverArtArchive/Jellyfin.Plugin.CoverArtArchive.csproj
+++ b/Jellyfin.Plugin.CoverArtArchive/Jellyfin.Plugin.CoverArtArchive.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.CoverArtArchive</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <NoWarn>$(NoWarn);CA1873</NoWarn>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@ name: "Cover Art Archive"
 guid: "8119f3c6-cfc2-4d9c-a0ba-028f1d93e526"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-coverartarchive.png"
 version: 9
-targetAbi: "10.11.0.0"
+targetAbi: "10.12.0.0"
 framework: "net9.0"
 overview: "MusicBrainz Cover Art Archive"
 description: >

--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ guid: "8119f3c6-cfc2-4d9c-a0ba-028f1d93e526"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-coverartarchive.png"
 version: 9
 targetAbi: "12.0.0.0"
-framework: "net9.0"
+framework: "net10.0"
 overview: "MusicBrainz Cover Art Archive"
 description: >
   This plugin provides images from the Cover Art Archive https://musicbrainz.org/doc/Cover_Art_Archive and depends on the MusicBrainz metadata provider to know what images belong where

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@ name: "Cover Art Archive"
 guid: "8119f3c6-cfc2-4d9c-a0ba-028f1d93e526"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-coverartarchive.png"
 version: 9
-targetAbi: "10.12.0.0"
+targetAbi: "12.0.0.0"
 framework: "net9.0"
 overview: "MusicBrainz Cover Art Archive"
 description: >

--- a/jellyfin.ruleset
+++ b/jellyfin.ruleset
@@ -114,5 +114,7 @@
         <Rule Id="CA2101" Action="None" />
         <!-- disable warning CA2234: Pass System.Uri objects instead of strings -->
         <Rule Id="CA2234" Action="None" />
+        <!-- disable warning CA1873: Evaluation of this argument may be expensive and unnecessary if logging is disabled -->
+        <Rule Id="CA1873" Action="None" />
     </Rules>
 </RuleSet>


### PR DESCRIPTION
Update Jellyfin NuGet package version to `10.*-*`.